### PR TITLE
Add comparison analysis: Claude Opus 4.6 Agent Teams vs isA Agent SDK

### DIFF
--- a/docs/comparison-claude-agent-teams-vs-isa-sdk.md
+++ b/docs/comparison-claude-agent-teams-vs-isa-sdk.md
@@ -1,0 +1,290 @@
+# Claude Opus 4.6 Agent Teams vs isA Agent SDK: Architecture Comparison
+
+## Executive Summary
+
+Claude Opus 4.6 (released Feb 5, 2026) introduces **Agent Teams** — a research preview where multiple independent Claude Code sessions collaborate peer-to-peer via shared inboxes and a task system. The isA Agent SDK uses **LangGraph-based graph orchestration** where specialized nodes communicate through shared state within a single execution graph. Both approaches solve multi-agent coordination but from fundamentally different directions.
+
+---
+
+## 1. Architecture Comparison at a Glance
+
+| Dimension | Claude Opus 4.6 Agent Teams | isA Agent SDK |
+|---|---|---|
+| **Paradigm** | Independent sessions with peer-to-peer messaging | Graph-based node orchestration with shared state |
+| **Communication** | File-based inboxes (JSON), async polling | LangGraph message list in `AgentState` |
+| **Agent Lifetime** | Persistent until shutdown | Request-scoped (per graph execution) |
+| **Coordination** | Shared task DAG + inbox messages | Conditional routing via `next_action` field |
+| **State Management** | File system (`~/.claude/teams/`, `~/.claude/tasks/`) | PostgreSQL checkpointing + Redis sessions |
+| **Human-in-the-Loop** | Plan approval mode per agent | Full HIL service with interrupt-based flow |
+| **Scaling** | Spawn backends (tmux, iTerm2, in-process) | Pool Manager with isolated VMs |
+| **Context** | Each agent has its own context window | Single shared context within a graph |
+| **Tool Access** | Per-agent-type tool restrictions | MCP-based tool discovery (explicit/semantic/hybrid) |
+| **Failure Recovery** | 5-min heartbeat timeout, auto-mark inactive | Durable checkpointing, circuit breakers, retry |
+
+---
+
+## 2. Deep Dive: Key Architectural Differences
+
+### 2.1 Agent Communication
+
+**Claude Agent Teams** use a **peer-to-peer inbox model**:
+- Messages stored as JSON in `~/.claude/teams/{name}/inboxes/{agent}.json`
+- Any agent can `write` to any other agent or `broadcast` to all
+- Agents poll their inboxes asynchronously
+- Structured message types: `shutdown_request`, `task_completed`, `plan_approval_request`, etc.
+
+**isA Agent SDK** uses **LangGraph state propagation**:
+- All communication flows through `AgentState.messages` (an annotated list)
+- Nodes produce state updates that the next node consumes
+- Routing is deterministic via `next_action` conditional edges
+- No direct agent-to-agent messaging — all communication is mediated by the graph
+
+**Implication**: Claude's model is more flexible for emergent collaboration (agents can self-organize), while isA's model is more predictable and easier to debug (execution follows a defined graph).
+
+### 2.2 Orchestration Patterns
+
+**Claude Agent Teams** supports 4 documented patterns:
+
+| Pattern | Description |
+|---|---|
+| **Leader** | One coordinator spawns parallel specialists |
+| **Pipeline** | Sequential tasks with `blockedBy` dependencies |
+| **Swarm** | Self-organizing; agents claim unclaimed tasks |
+| **Pipeline + Approval** | Pipeline with plan-mode watchdog gates |
+
+**isA Agent SDK** implements orchestration through graph types:
+
+| Graph Type | Pattern |
+|---|---|
+| **SmartAgentGraph** | Sense → Reason → Act → Respond (full pipeline) |
+| **ConversationGraph** | Simple Reason → Respond (minimal) |
+| **ResearchGraph** | Multi-loop search-reason cycles |
+| **CodingGraph** | Reason → Act with strict guardrails |
+
+Plus execution modes within `AgentExecutorNode`: sequential task list, parallel (up to N concurrent), and distributed (Pool Manager VMs).
+
+**Key Difference**: Claude's patterns are emergent — agents negotiate coordination at runtime. isA's patterns are structural — the graph topology defines coordination at build time.
+
+### 2.3 Task Management
+
+**Claude Agent Teams** has a first-class task system:
+- `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate` operations
+- Tasks stored as individual JSON files (`~/.claude/tasks/{team}/N.json`)
+- DAG support: tasks can declare `blockedBy` and `blocks` relationships
+- Any agent can create, claim, or complete tasks
+- Status: `pending` → `in_progress` → `completed`
+
+**isA Agent SDK** tracks tasks within `AgentState`:
+```python
+task_list: List[Dict[str, Any]]
+current_task_index: int
+execution_mode: str  # "sequential" or "parallel"
+completed_task_count: int
+failed_task_count: int
+```
+- Tasks are processed by `AgentExecutorNode`
+- No cross-agent task claiming (tasks belong to the current graph execution)
+- No DAG dependencies between tasks
+
+**What we can learn**: Claude's task DAG system with blocking dependencies is powerful. isA could benefit from a similar dependency-aware task system that allows tasks to express prerequisite relationships.
+
+### 2.4 Agent Specialization
+
+**Claude Agent Teams** defines agent types with tool restrictions:
+
+| Type | Tools | Use Case |
+|---|---|---|
+| Bash | Bash only | Git, CLI operations |
+| Explore | Read-only | Codebase search |
+| Plan | Read-only | Architecture design |
+| general-purpose | All tools | Multi-step work |
+
+**isA Agent SDK** defines specialization through node types:
+
+| Node | Role |
+|---|---|
+| SenseNode | Intent classification, routing |
+| ReasonNode | LLM reasoning, tool selection |
+| ToolNode | Tool execution, security |
+| AgentExecutorNode | Autonomous task coordination |
+| GuardrailNode | Compliance checking |
+| FailsafeNode | Confidence assessment |
+| ResponseNode | Final formatting |
+| SummarizationNode | Context compression |
+
+**Key Difference**: Claude specializes at the session level (each agent is a full Claude instance with restricted tools). isA specializes at the function level (each node handles one aspect of the reasoning pipeline). isA's approach is more fine-grained but doesn't support multiple independent reasoning chains running simultaneously.
+
+### 2.5 Context and Memory
+
+**Claude Agent Teams**:
+- Each agent has its own independent context window (up to 1M tokens in Opus 4.6)
+- No shared memory beyond task files and inbox messages
+- Context compaction available within each agent
+- No session resumption across team lifetimes
+
+**isA Agent SDK**:
+- Single shared context within a graph via `AgentState`
+- `SummarizationNode` compresses conversation history
+- PostgreSQL checkpointing enables session resumption
+- Redis-backed session management
+- Memory context loaded via `RuntimeContextHelper`
+
+**What we can learn**: Independent context windows mean agents don't pollute each other's reasoning. The Writer/Reviewer pattern (one agent writes, another reviews in a clean context) is particularly powerful because the reviewer is unbiased. isA could adopt this by spinning up separate graph executions for review tasks.
+
+---
+
+## 3. What We Can Learn from Claude Opus 4.6 Agent Teams
+
+### 3.1 Peer-to-Peer Communication Layer
+
+**Current isA limitation**: All communication goes through the graph state. Agents can't message each other directly.
+
+**Lesson**: Add an optional messaging layer (e.g., via Redis pub/sub or NATS) that allows nodes or subgraphs to communicate asynchronously. This would enable patterns like:
+- A research subgraph notifying a coding subgraph when analysis is complete
+- A guardrail agent broadcasting warnings to all active nodes
+
+**Suggested Implementation**:
+```python
+class AgentMessaging:
+    """Peer-to-peer communication between graph executions"""
+    async def send(target_agent_id: str, message: Dict)
+    async def broadcast(team_id: str, message: Dict)
+    async def poll(agent_id: str) -> List[Dict]
+```
+
+### 3.2 Task DAG with Dependency Management
+
+**Current isA limitation**: Tasks in `AgentState.task_list` are a flat list processed sequentially or in parallel, with no dependency awareness.
+
+**Lesson**: Implement a task system with explicit blocking dependencies:
+```python
+@dataclass
+class AgentTask:
+    id: str
+    title: str
+    description: str
+    status: str  # pending, blocked, in_progress, completed
+    owner: Optional[str]
+    blocked_by: List[str]  # Task IDs
+    blocks: List[str]      # Task IDs
+```
+
+When a task completes, automatically unblock dependent tasks. This enables complex workflows like:
+```
+Research → Plan → [Implement Frontend, Implement Backend] → Integration Test → Deploy
+```
+
+### 3.3 Swarm / Self-Organizing Pattern
+
+**Current isA limitation**: Agent orchestration is structurally defined — the graph topology is fixed at build time.
+
+**Lesson**: Support a swarm mode where multiple graph instances share a task queue and self-organize:
+- Each instance polls for unclaimed tasks
+- First to claim wins (optimistic locking)
+- Naturally load-balancing without a central coordinator
+
+This could integrate with the existing Pool Manager:
+```python
+class SwarmExecutor:
+    """Multiple VMs pulling from shared task queue"""
+    async def run_swarm(task_queue: str, max_workers: int):
+        vms = await pool_manager.acquire_multiple(max_workers)
+        for vm in vms:
+            await vm.start_worker(task_queue)
+```
+
+### 3.4 Independent Context Windows (Writer/Reviewer Pattern)
+
+**Current isA limitation**: All nodes share the same `AgentState.messages`, so a reviewer node sees the same context that generated the code — introducing potential bias.
+
+**Lesson**: For quality-critical workflows, spin up a separate graph execution for review:
+1. Writer graph produces an artifact (code, document, plan)
+2. Reviewer graph receives only the artifact and requirements — not the generation context
+3. Reviewer provides unbiased feedback
+
+This maps naturally to isA's Pool Manager: the reviewer runs in an isolated VM with a clean context.
+
+### 3.5 Spawn Backends for Visibility
+
+**Current isA limitation**: Distributed execution via Pool Manager is invisible to operators.
+
+**Lesson**: Claude's tmux/iTerm2 backends let developers see all agents working in real-time split panes. isA could offer a similar debug mode:
+- Terminal multiplexing for local development
+- A web dashboard showing all active graph executions and their states
+- Real-time streaming of each node's reasoning
+
+### 3.6 Structured Shutdown and Lifecycle Management
+
+**Claude Agent Teams** has explicit lifecycle operations: `requestShutdown`, `approveShutdown`, `cleanup`.
+
+**Current isA approach**: Graph execution ends when the graph reaches END or times out.
+
+**Lesson**: For long-running autonomous agents (proactive mode), add graceful shutdown protocols:
+- Allow external signals to request graceful termination
+- Agents complete current work before stopping
+- Cleanup resources (MCP connections, VM allocations)
+
+---
+
+## 4. Where isA Agent SDK Already Excels
+
+Not everything from Claude Agent Teams is an improvement. isA has strengths that Claude's approach lacks:
+
+### 4.1 Production Infrastructure
+- **Durable checkpointing** (PostgreSQL) enables session resumption — Claude Teams can't resume
+- **Circuit breakers and rate limiting** for resilience
+- **Consul service discovery** for microservice integration
+- **Loki logging and observability** built in
+
+### 4.2 Fine-Grained Security
+- **GuardrailNode** with configurable strictness (permissive/moderate/strict)
+- **Per-tool permission checking** in ToolNode
+- **HIL service** with structured approval workflows
+- Claude Teams relies on per-agent tool restrictions but has no guardrail pipeline
+
+### 4.3 Tool Discovery
+- **Semantic tool discovery** via MCP — tools found by meaning, not just name
+- **Hybrid mode** (explicit core + semantic expansion)
+- Claude Teams only supports explicit tool lists per agent type
+
+### 4.4 Execution Modes
+- **Reactive/Collaborative/Proactive** execution modes provide flexibility Claude Teams doesn't have
+- **Event-driven triggers** (schedule, price thresholds, business events) for autonomous operation
+- Claude Teams is purely on-demand
+
+### 4.5 Model Flexibility
+- isA supports **multiple model providers** (GPT-4.1, DeepSeek, Llama) for different roles
+- Each node can use a different model (reason_model vs response_model)
+- Claude Teams is locked to Claude models only
+
+---
+
+## 5. Recommended Improvements for isA Agent SDK
+
+Based on this analysis, here are prioritized improvements:
+
+### High Priority
+1. **Task DAG System** — Add dependency-aware task management with `blocked_by`/`blocks` relationships. This is the single most impactful feature from Claude Teams.
+2. **Independent Review Context** — Support spawning isolated graph executions for unbiased review (Writer/Reviewer pattern). Leverages existing Pool Manager.
+
+### Medium Priority
+3. **Inter-Graph Messaging** — Add a pub/sub layer for communication between concurrent graph executions. Use existing Redis infrastructure.
+4. **Swarm Executor** — Allow multiple Pool Manager VMs to pull from a shared task queue for dynamic load balancing.
+5. **Agent Lifecycle Management** — Graceful shutdown protocol for long-running proactive agents.
+
+### Lower Priority (Nice to Have)
+6. **Debug Visibility** — tmux-style split pane view for local development showing multiple agent streams.
+7. **Agent Naming** — Descriptive agent names (like Claude's "security-reviewer") instead of generic node types for better observability.
+
+---
+
+## 6. Conclusion
+
+Claude Opus 4.6 Agent Teams and isA Agent SDK represent two complementary philosophies:
+
+- **Claude Teams** = **Emergent coordination** — independent agents self-organize around a shared task board
+- **isA Agent SDK** = **Structural coordination** — specialized nodes follow a defined graph topology
+
+Claude's approach excels at **exploration and parallelism** — throw multiple agents at a problem and let them figure it out. isA's approach excels at **reliability and control** — every execution path is defined, checkpointed, and auditable.
+
+The biggest takeaway: **Claude's task DAG system and independent-context patterns can be adopted by isA without abandoning its graph-based architecture.** The task DAG can sit alongside the existing `AgentState.task_list`, and the Writer/Reviewer pattern can use Pool Manager VMs for context isolation. These additions would give isA the best of both worlds — structural reliability with emergent flexibility where it matters.


### PR DESCRIPTION
Research and document architectural differences between Claude's new
peer-to-peer Agent Teams (independent sessions, file-based inboxes,
task DAGs) and isA's LangGraph-based graph orchestration (shared state,
node specialization, structural routing). Identifies 7 actionable
improvements for isA, including task DAGs, writer/reviewer pattern,
inter-graph messaging, and swarm execution.

https://claude.ai/code/session_018JNAGw9W1VthNhujK3RH79