### PR TITLE
fix: resolve code review findings (issues #4-#10)

### DIFF
--- a/isa_agent_sdk/agent_types/agent_state.py
+++ b/isa_agent_sdk/agent_types/agent_state.py
@@ -68,8 +68,8 @@ class AgentState(TypedDict):
     execution_mode: Annotated[Optional[str], preserve_latest]  # "sequential" or "parallel"
 
     # Task execution tracking
-    completed_task_count: Annotated[Optional[int], sum_numeric]
-    failed_task_count: Annotated[Optional[int], sum_numeric]
+    completed_task_count: Annotated[Optional[int], preserve_latest]
+    failed_task_count: Annotated[Optional[int], preserve_latest]
 
     # Execution plan from planning tools
     execution_plan: Annotated[Optional[Dict[str, Any]], preserve_latest]

--- a/isa_agent_sdk/errors.py
+++ b/isa_agent_sdk/errors.py
@@ -50,7 +50,7 @@ class ISASDKError(Exception):
 # Connection & Infrastructure Errors
 # ============================================================================
 
-class ConnectionError(ISASDKError):
+class ISAConnectionError(ISASDKError):
     """
     Failed to connect to a required service.
 
@@ -74,7 +74,7 @@ class ConnectionError(ISASDKError):
         self.details["url"] = url
 
 
-class TimeoutError(ISASDKError):
+class ISATimeoutError(ISASDKError):
     """
     Operation timed out.
 
@@ -337,7 +337,7 @@ class ResumeError(SessionError):
 # Validation Errors
 # ============================================================================
 
-class ValidationError(ISASDKError):
+class ISAValidationError(ISASDKError):
     """
     Input validation failed.
 
@@ -358,7 +358,7 @@ class ValidationError(ISASDKError):
         # Don't include value in details (might be sensitive)
 
 
-class SchemaError(ValidationError):
+class SchemaError(ISAValidationError):
     """
     Schema validation failed.
 
@@ -381,7 +381,7 @@ class SchemaError(ValidationError):
         self.details["errors"] = self.errors
 
 
-class ConfigurationError(ValidationError):
+class ConfigurationError(ISAValidationError):
     """
     Configuration is invalid.
 
@@ -394,7 +394,7 @@ class ConfigurationError(ValidationError):
 # Permission & Authorization Errors
 # ============================================================================
 
-class PermissionError(ISASDKError):
+class ISAPermissionError(ISASDKError):
     """
     Permission denied.
 
@@ -415,7 +415,7 @@ class PermissionError(ISASDKError):
         self.details["resource"] = resource
 
 
-class ToolPermissionError(PermissionError):
+class ToolPermissionError(ISAPermissionError):
     """
     Tool execution not permitted.
 
@@ -432,7 +432,7 @@ class ToolPermissionError(PermissionError):
         self.tool_name = tool_name
 
 
-class HILDeniedError(PermissionError):
+class HILDeniedError(ISAPermissionError):
     """
     Human-in-the-loop request was denied.
 
@@ -453,7 +453,7 @@ class HILDeniedError(PermissionError):
         self.details["session_id"] = session_id
 
 
-class HILTimeoutError(PermissionError):
+class HILTimeoutError(ISAPermissionError):
     """
     Human-in-the-loop request timed out.
 
@@ -496,7 +496,7 @@ class MCPError(ISASDKError):
         self.details["server_name"] = server_name
 
 
-class MCPConnectionError(MCPError, ConnectionError):
+class MCPConnectionError(MCPError, ISAConnectionError):
     """
     Failed to connect to MCP server.
     """
@@ -529,8 +529,8 @@ __all__ = [
     "ISASDKError",
 
     # Connection & Infrastructure
-    "ConnectionError",
-    "TimeoutError",
+    "ISAConnectionError",
+    "ISATimeoutError",
     "CircuitBreakerError",
     "RateLimitError",
 
@@ -549,12 +549,12 @@ __all__ = [
     "ResumeError",
 
     # Validation
-    "ValidationError",
+    "ISAValidationError",
     "SchemaError",
     "ConfigurationError",
 
     # Permission & Authorization
-    "PermissionError",
+    "ISAPermissionError",
     "ToolPermissionError",
     "HILDeniedError",
     "HILTimeoutError",
@@ -563,4 +563,16 @@ __all__ = [
     "MCPError",
     "MCPConnectionError",
     "MCPToolNotFoundError",
+
+    # Backward-compat aliases (deprecated — use ISA-prefixed names)
+    "ConnectionError",
+    "TimeoutError",
+    "ValidationError",
+    "PermissionError",
 ]
+
+# Backward-compat aliases (deprecated — use ISA-prefixed names)
+ConnectionError = ISAConnectionError
+TimeoutError = ISATimeoutError
+ValidationError = ISAValidationError
+PermissionError = ISAPermissionError

--- a/isa_agent_sdk/graphs/utils/context_init.py
+++ b/isa_agent_sdk/graphs/utils/context_init.py
@@ -177,11 +177,9 @@ class RuntimeContextHelper:
                     f"tools_count={len(cached_tools)} | "
                     f"duration_ms={cache_hit_duration}"
                 )
-                self._cache_stats['hits'] += 1
                 return cached_tools
 
             # Cache miss - perform search
-            self._cache_stats['misses'] += 1
             self.logger.info(
                 f"[PHASE:CONTEXT] tool_search_cache_miss | "
                 f"query='{user_query[:50]}' | "
@@ -1134,10 +1132,10 @@ _runtime_helper = None
 
 
 async def get_runtime_helper(mcp_url: str = None) -> RuntimeContextHelper:
+    """Get global runtime helper instance"""
     if mcp_url is None:
         from isa_agent_sdk.core.config import settings
         mcp_url = settings.resolved_mcp_server_url + "/mcp"
-    """Get global runtime helper instance"""
     global _runtime_helper
     
     if _runtime_helper is None:
@@ -1334,10 +1332,10 @@ def create_initial_state(user_query: str) -> Dict[str, Any]:
 
 
 async def get_runtime_cache_stats(mcp_url: str = None) -> Dict[str, Any]:
+    """Get runtime cache performance statistics"""
     if mcp_url is None:
         from isa_agent_sdk.core.config import settings
         mcp_url = settings.resolved_mcp_server_url + "/mcp"
-    """Get runtime cache performance statistics"""
     try:
         helper = await get_runtime_helper(mcp_url)
         return helper.get_cache_stats()
@@ -1347,10 +1345,10 @@ async def get_runtime_cache_stats(mcp_url: str = None) -> Dict[str, Any]:
 
 
 async def clear_runtime_cache(cache_type: Optional[str] = None, mcp_url: str = None):
+    """Clear runtime cache"""
     if mcp_url is None:
         from isa_agent_sdk.core.config import settings
         mcp_url = settings.resolved_mcp_server_url + "/mcp"
-    """Clear runtime cache"""
     try:
         helper = await get_runtime_helper(mcp_url)
         helper.clear_cache(cache_type)

--- a/isa_agent_sdk/services/agent_config_store.py
+++ b/isa_agent_sdk/services/agent_config_store.py
@@ -9,6 +9,7 @@ isa_common.AsyncPostgresClient (native asyncpg).
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import datetime
 from enum import Enum
@@ -81,6 +82,9 @@ class AgentConfigStore:
     ):
         infra = settings.infrastructure
         self.schema = schema or settings.resources.postgres.schema or "agent"
+
+        if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', self.schema):
+            raise ValueError(f"Invalid schema name: {self.schema!r}")
 
         self.db = AsyncPostgresClient(
             host=host or infra.postgres_host,


### PR DESCRIPTION
## Summary
- **#4 agent_state**: Switch `completed_task_count`/`failed_task_count` from `sum_numeric` to `preserve_latest` reducer — prevents accidental double-counting across graph iterations
- **#4 agent_executor_node**: Fix timeout handler in `_execute_parallel_tasks` that returned a bare `{"next_action": ...}` dict instead of the full `state`, dropping all accumulated state
- **#10 agent_executor_node**: Fix string-vs-enum comparison in `_handle_dag_deadlocked` — `t.status in ("pending", ...)` never matched `DAGTaskStatus` enum values
- **#5 agent_config_store**: Add regex validation for `schema` parameter to prevent SQL injection (asyncpg doesn't support parameterized identifiers)
- **#6 errors**: Rename `ConnectionError`/`TimeoutError`/`ValidationError`/`PermissionError` to `ISAConnectionError`/`ISATimeoutError`/`ISAValidationError`/`ISAPermissionError` to stop shadowing Python builtins; backward-compat aliases preserved
- **#7 swarm**: Add `asyncio.Lock` around shared-state mutations in `run_dag` to prevent data races when agents run concurrently; guard `msg.metadata` assignment in `stream()`
- **#8 base_node**: Store `state`/`config` in `contextvars.ContextVar` instead of instance attributes — makes concurrent node execution safe while preserving the `self.state`/`self.config` API
- **#9 context_init**: Fix 3 misplaced docstrings (placed after `if mcp_url` instead of before), remove double-counted cache stats in `search_relevant_tools`

## Test plan
- [x] All 148 existing tests pass (`test_dag`, `test_swarm`, `test_agent_config_store`, `test_agent_creation`, `test_agent_creation_generated`, `test_multi_agent_runner`)
- [x] Import verification for new ISA-prefixed names + backward-compat aliases
- [ ] Manual smoke test of DAG execution flow
- [ ] Manual smoke test of swarm `run_dag` with concurrent agents

Closes #4, #5, #6, #7, #8, #9, #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)