### PR TITLE
chore: fix minor code quality issues (issue #10)

### DIFF
--- a/isa_agent_sdk/_tools.py
+++ b/isa_agent_sdk/_tools.py
@@ -20,7 +20,8 @@ Example:
         "required": ["expression"]
     })
     async def calculate(expression: str) -> dict:
-        result = eval(expression)  # Note: use safe eval in production
+        import ast
+        result = ast.literal_eval(expression)  # Safe: only evaluates literals
         return {"result": result, "expression": expression}
 
     # Create SDK MCP server with your tools

--- a/isa_agent_sdk/dag/scheduler.py
+++ b/isa_agent_sdk/dag/scheduler.py
@@ -75,14 +75,6 @@ class DAGScheduler:
 
         # Cycle detection via Kahn's algorithm
         if not errors:
-            in_degree: Dict[str, int] = {tid: 0 for tid in all_ids}
-            for task in dag.tasks.values():
-                for dep_id in task.depends_on:
-                    if dep_id in in_degree:
-                        # dep_id -> task (task depends on dep_id)
-                        # We track in-degree of each task
-                        pass
-            # Recompute: in-degree = number of dependencies for each task
             in_degree = {tid: len(dag.tasks[tid].depends_on) for tid in all_ids}
 
             queue = deque(tid for tid, deg in in_degree.items() if deg == 0)

--- a/isa_agent_sdk/nodes/tool_node.py
+++ b/isa_agent_sdk/nodes/tool_node.py
@@ -426,21 +426,25 @@ class ToolNode(BaseNode):
             Plan data dict if create_execution_plan succeeded, None otherwise
         """
         # Check if create_execution_plan was called
-        plan_tool_index = None
-        for i, (tool_name, tool_args, tool_call_id) in enumerate(tool_info_list):
+        plan_tool_call_id = None
+        for tool_name, tool_args, tool_call_id in tool_info_list:
             if tool_name == 'create_execution_plan':
-                plan_tool_index = i
+                plan_tool_call_id = tool_call_id
                 break
 
-        if plan_tool_index is None:
+        if plan_tool_call_id is None:
             return None
 
-        # Find the corresponding tool message
-        if plan_tool_index >= len(tool_messages):
+        # Find the corresponding tool message by matching tool_call_id
+        plan_message = None
+        for msg in tool_messages:
+            if getattr(msg, 'tool_call_id', None) == plan_tool_call_id:
+                plan_message = msg
+                break
+
+        if plan_message is None:
             self.logger.warning("[AUTONOMOUS] Plan tool called but no response message found")
             return None
-
-        plan_message = tool_messages[plan_tool_index]
         content = str(plan_message.content)
 
         # Parse the plan response

--- a/isa_agent_sdk/options.py
+++ b/isa_agent_sdk/options.py
@@ -769,4 +769,6 @@ __all__ = [
     "HookMatcher",
     "PoolConfig",
     "TriggerConfig",
+    "SystemPromptConfig",
+    "SystemPromptPreset",
 ]

--- a/isa_agent_sdk/services/agent_creation.py
+++ b/isa_agent_sdk/services/agent_creation.py
@@ -11,7 +11,7 @@ Implements the four agent creation flows:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
 from .agent_config_store import (
@@ -59,7 +59,7 @@ class AgentCreationService:
             graph_type=graph_type,
         )
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         record = AgentConfigRecord(
             id=await self.store.new_config_id(),
             owner_id=owner_id,
@@ -117,7 +117,7 @@ class AgentCreationService:
             owner_id=owner_id,
             name=merged["name"],
             description=merged.get("description", ""),
-            model_id=merged.get("model_id") or overrides.get("model_id") or "gpt-5-nano",
+            model_id=merged.get("model_id") or "gpt-5-nano",
             system_prompt=merged.get("system_prompt", ""),
             tools=merged.get("tools"),
             skills=merged.get("skills"),
@@ -273,7 +273,7 @@ class AgentCreationService:
                 "agents list is empty or missing id/name"
             )
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         record = MultiAgentSpecRecord(
             id=await self.store.new_multi_id(),
             owner_id=owner_id,


### PR DESCRIPTION
## Summary
Addresses all actionable items from issue #10 (P3-Low code quality findings from PR #3 review).

- **agent_creation.py**: Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` (2 sites); remove redundant `overrides.get("model_id")` fallback (already merged into `merged` dict)
- **dag/scheduler.py**: Remove dead code in `validate()` — loop body was `pass`, result immediately overwritten on next line
- **handoff.py**: Fix tail window / `rfind` mismatch — use `match.start()` + tail offset to compute directive position instead of `rfind` on full text (could find different occurrence)
- **tool_node.py**: Fix potential index mismatch in `_detect_autonomous_plan` — match plan tool message by `tool_call_id` instead of positional index (indices can diverge if earlier tools produce different message counts)
- **agent_client.py**: Fix asyncio anti-pattern (`run_until_complete` on already-running loop → use thread-based bridge); remove hardcoded `"dev_key_test"` fallback (now raises `ValueError`); use UUID for session IDs instead of millisecond timestamps
- **model_client.py**: Fix `isa_url: str = None` → `Optional[str] = None`; lazily create `asyncio.Lock` to avoid module-level event loop dependency
- **options.py**: Add `SystemPromptConfig` and `SystemPromptPreset` to `__all__`
- **_tools.py**: Replace `eval()` with `ast.literal_eval()` in docstring example
- **a2a.py**: Add TTL-based eviction (`_evict_stale_tasks`) with 1-hour TTL and 1000-task cap to prevent unbounded memory growth

## Not addressed (would need separate discussion)
- `test_swarm_e2e.py`, `test_client.py`, `test_memory_e2e.py` standalone scripts → converting to pytest is a larger task
- `test_swarm.py` / `test_dag.py` weak assertions → best done alongside feature work

## Test plan
- [x] All 148 existing tests pass
- [x] Import verification for new `__all__` exports
- [ ] Manual test of `agent_client.py` sync wrappers in async context
- [ ] Manual test of `ISAAgent` initialization without API key (should raise `ValueError`)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)