### PR TITLE
fix: resolve P1 audit findings (#13-#18)

### DIFF
--- a/isa_agent_sdk/_query.py
+++ b/isa_agent_sdk/_query.py
@@ -173,6 +173,17 @@ def query_sync(
         for msg in query_sync("Hello"):
             print(msg.content)
     """
+    # Detect already-running event loop (e.g. called from async context)
+    try:
+        asyncio.get_running_loop()
+        raise RuntimeError(
+            "query_sync() cannot be called from an async context. "
+            "Use query() (async) instead, or run from a synchronous context."
+        )
+    except RuntimeError as e:
+        if "no current event loop" not in str(e).lower() and "no running event loop" not in str(e).lower():
+            raise
+
     # Always create a fresh event loop for sync execution
     # This avoids issues with closed loops from previous asyncio.run() calls
     loop = asyncio.new_event_loop()
@@ -1033,6 +1044,17 @@ async def ask(prompt: str, **kwargs) -> str:
 
 def ask_sync(prompt: str, **kwargs) -> str:
     """Synchronous version of ask()"""
+    # Detect already-running event loop (e.g. called from async context)
+    try:
+        asyncio.get_running_loop()
+        raise RuntimeError(
+            "ask_sync() cannot be called from an async context. "
+            "Use ask() (async) instead, or run from a synchronous context."
+        )
+    except RuntimeError as e:
+        if "no current event loop" not in str(e).lower() and "no running event loop" not in str(e).lower():
+            raise
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
@@ -1144,6 +1166,17 @@ def resume_sync(
     options: Optional[ISAAgentOptions] = None,
 ) -> Iterator[AgentMessage]:
     """Synchronous version of resume()"""
+    # Detect already-running event loop (e.g. called from async context)
+    try:
+        asyncio.get_running_loop()
+        raise RuntimeError(
+            "resume_sync() cannot be called from an async context. "
+            "Use resume() (async) instead, or run from a synchronous context."
+        )
+    except RuntimeError as e:
+        if "no current event loop" not in str(e).lower() and "no running event loop" not in str(e).lower():
+            raise
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 

--- a/isa_agent_sdk/agents/handoff.py
+++ b/isa_agent_sdk/agents/handoff.py
@@ -138,6 +138,12 @@ def parse_handoff_from_response(
         return HandoffResult(action=HandoffAction.COMPLETE)
 
     # No directive found — treat as complete (safe default)
+    tail_snippet = response_text[-80:] if len(response_text) > 80 else response_text
+    logger.info(
+        "No handoff directive found in response; defaulting to COMPLETE. "
+        "Response tail: %r",
+        tail_snippet,
+    )
     return HandoffResult(action=HandoffAction.COMPLETE)
 
 

--- a/isa_agent_sdk/agents/swarm.py
+++ b/isa_agent_sdk/agents/swarm.py
@@ -118,6 +118,15 @@ class SwarmOrchestrator:
             shared_state=dict(self._initial_shared_state),
         )
 
+        # Validate active agent before entering the loop
+        if not swarm_state.active_agent:
+            raise ValueError("swarm_state.active_agent must be set")
+        if swarm_state.active_agent not in self._agents:
+            raise KeyError(
+                f"Active agent '{swarm_state.active_agent}' not in swarm. "
+                f"Available: {list(self._agents.keys())}"
+            )
+
         agent_outputs: Dict[str, AgentRunResult] = {}
         all_messages: List[AgentMessage] = []
         current_prompt = prompt
@@ -223,6 +232,15 @@ class SwarmOrchestrator:
             active_agent=self.entry_agent,
             shared_state=dict(self._initial_shared_state),
         )
+
+        # Validate active agent before entering the loop
+        if not swarm_state.active_agent:
+            raise ValueError("swarm_state.active_agent must be set")
+        if swarm_state.active_agent not in self._agents:
+            raise KeyError(
+                f"Active agent '{swarm_state.active_agent}' not in swarm. "
+                f"Available: {list(self._agents.keys())}"
+            )
 
         current_prompt = prompt
 

--- a/isa_agent_sdk/nodes/agent_executor_node.py
+++ b/isa_agent_sdk/nodes/agent_executor_node.py
@@ -1119,7 +1119,8 @@ Your choice:"""
 
             max_confidence = max(user_needs_confidence, task_outcomes_confidence, resource_requirements_confidence, execution_patterns_confidence, user_patterns_confidence)
             return max_confidence > 0.7
-        except:
+        except (TypeError, ValueError, AttributeError, KeyError) as e:
+            self.logger.debug(f"Prediction confidence check failed: {e}")
             return False
 
     # =============================================================================

--- a/isa_agent_sdk/options.py
+++ b/isa_agent_sdk/options.py
@@ -307,6 +307,10 @@ class MCPServerConfig:
     def __post_init__(self):
         if not self.command and not self.url:
             raise ValueError("MCPServerConfig requires either 'command' or 'url'")
+        if self.url and not any(self.url.startswith(p) for p in ("http://", "https://", "ws://", "wss://")):
+            raise ValueError(
+                f"url must start with http://, https://, ws://, or wss://, got '{self.url}'"
+            )
 
 
 @dataclass
@@ -630,6 +634,19 @@ class ISAAgentOptions:
             self.tool_discovery = ToolDiscoveryMode(self.tool_discovery)
         if isinstance(self.guardrail_mode, str):
             self.guardrail_mode = GuardrailMode(self.guardrail_mode)
+
+        # Validate numeric ranges
+        if self.max_iterations is not None and self.max_iterations <= 0:
+            raise ValueError(f"max_iterations must be positive, got {self.max_iterations}")
+        if not (0.0 <= self.failsafe_confidence_threshold <= 1.0):
+            raise ValueError(
+                f"failsafe_confidence_threshold must be in [0.0, 1.0], "
+                f"got {self.failsafe_confidence_threshold}"
+            )
+        if self.summarization_threshold is not None and self.summarization_threshold <= 0:
+            raise ValueError(
+                f"summarization_threshold must be positive, got {self.summarization_threshold}"
+            )
 
         # Convert MCP server dicts to MCPServerConfig (preserve SDKMCPServer as-is)
         if self.mcp_servers:


### PR DESCRIPTION
## Summary

- **#13** — Message reducer bypass: Verified as false positive. `state["messages"] = [result_message]` followed by `return state` correctly goes through LangGraph's `add_messages` reducer.
- **#15** — Bare `except:` in `_has_high_confidence_predictions`: Replaced with specific exception types (`TypeError`, `ValueError`, `AttributeError`, `KeyError`) and added debug logging.
- **#16** — Event loop race in sync wrappers: Added running loop detection at the top of `query_sync()`, `ask_sync()`, and `resume_sync()`. Raises clear `RuntimeError` with guidance when called from async context.
- **#17** — Swarm state validation: Added `active_agent` validation before the main loop in both `run()` and `stream()`. Added `logger.info()` on silent COMPLETE fallback in `parse_handoff_from_response()`.
- **#18** — Options validation: Added numeric range checks for `max_iterations`, `failsafe_confidence_threshold`, and `summarization_threshold` in `ISAAgentOptions.__post_init__()`. Added URL protocol validation in `MCPServerConfig`.

## Test plan

- [x] All 190 existing tests pass (`python -m pytest tests/ -v`)
- [x] Import verification for all modified modules
- [x] Validation correctly rejects: `max_iterations=-1`, `failsafe_confidence_threshold=1.5`, `summarization_threshold=-5`, `MCPServerConfig(url='ftp://...')`
- [x] Validation accepts valid values
- [x] Event loop detection raises correct error when `query_sync()` called from async context
- [x] Normal sync callers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)