### PR TITLE
fix(types): add type hints to reducer functions (Issue #40)

### DIFF
--- a/isa_agent_sdk/agent_types/agent_state.py
+++ b/isa_agent_sdk/agent_types/agent_state.py
@@ -1,19 +1,42 @@
 """
 Agent State definition for LangGraph
+
+This module defines the state schema and reducer functions for LangGraph agent workflows.
+All reducers are fully typed to ensure type safety across the codebase.
 """
-from typing import Annotated, Optional, Dict, Any, List, TypedDict
+from typing import Annotated, Optional, Dict, Any, List, TypedDict, TypeVar, Union
 from langchain_core.messages import AnyMessage
 from langgraph.graph.message import add_messages
 from langgraph.managed.is_last_step import RemainingSteps
 
+T = TypeVar('T')
 
-def preserve_latest(existing, new):
-    """Reducer that preserves the latest non-empty value"""
+
+def preserve_latest(existing: Optional[T], new: Optional[T]) -> Optional[T]:
+    """
+    Reducer that preserves the latest non-empty value.
+
+    Args:
+        existing: The current value in state
+        new: The new value to potentially apply
+
+    Returns:
+        The new value if it is not None and not empty string, otherwise existing
+    """
     return new if new is not None and new != "" else existing
 
 
-def append_if_not_none(existing, new):
-    """Reducer that appends new items to existing list if new is not None"""
+def append_if_not_none(existing: Optional[List[Any]], new: Optional[Union[Any, List[Any]]]) -> List[Any]:
+    """
+    Reducer that appends new items to existing list if new is not None.
+
+    Args:
+        existing: The current list in state (or None)
+        new: The new item(s) to append (single item or list)
+
+    Returns:
+        Updated list with new items appended
+    """
     if existing is None:
         existing = []
     if new is None:
@@ -23,8 +46,17 @@ def append_if_not_none(existing, new):
     return existing + [new]
 
 
-def merge_dicts(existing, new):
-    """Reducer that merges dictionaries, with new values overwriting existing"""
+def merge_dicts(existing: Optional[Dict[str, Any]], new: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Reducer that merges dictionaries, with new values overwriting existing.
+
+    Args:
+        existing: The current dictionary in state (or None)
+        new: The new dictionary to merge
+
+    Returns:
+        Merged dictionary with new values taking precedence
+    """
     if existing is None:
         existing = {}
     if new is None:
@@ -32,8 +64,17 @@ def merge_dicts(existing, new):
     return {**existing, **new}
 
 
-def sum_numeric(existing, new):
-    """Reducer that sums numeric values"""
+def sum_numeric(existing: Optional[Union[int, float]], new: Optional[Union[int, float]]) -> Union[int, float]:
+    """
+    Reducer that sums numeric values.
+
+    Args:
+        existing: The current numeric value in state (or None)
+        new: The new numeric value to add
+
+    Returns:
+        Sum of existing and new values
+    """
     if existing is None:
         existing = 0
     if new is None:


### PR DESCRIPTION
## Summary
Adds comprehensive type hints to all reducer functions in `agent_state.py` to improve type safety and IDE support.

## Changes

**Type Hints Added:**
- ✅ `preserve_latest` - Uses generic `TypeVar[T]` for type preservation
- ✅ `append_if_not_none` - Types list operations
- ✅ `merge_dicts` - Types dictionary merging  
- ✅ `sum_numeric` - Types numeric operations using `Union[int, float]`

**Documentation:**
- Enhanced all docstrings with Args and Returns sections
- Added module-level documentation explaining reducer typing

## Verification

| Check | Status |
|-------|--------|
| mypy on agent_state.py | ✅ 0 errors |
| Reducer function tests | ✅ All passing |
| Python syntax | ✅ Valid |
| Module imports | ✅ Successful |

## Type Signatures

```python
def preserve_latest(existing: Optional[T], new: Optional[T]) -> Optional[T]
def append_if_not_none(existing: Optional[List[Any]], new: Optional[Union[Any, List[Any]]]) -> List[Any]
def merge_dicts(existing: Optional[Dict[str, Any]], new: Optional[Dict[str, Any]]) -> Dict[str, Any]
def sum_numeric(existing: Optional[Union[int, float]], new: Optional[Union[int, float]]) -> Union[int, float]
```

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)